### PR TITLE
infra: fetch go automatically

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,10 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.23.x
+      - name: Install dependencies
+        run: make deps
 
       - name: Run Go tests
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ about.html
 posts.html
 posts/*.html
 feed.xml
+go/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,37 @@
 PORT ?= 9090
 DEST ?= site
 
+GO_VERSION := 1.25.3
+GO_DIR := go
+
+GO_OS_RAW := $(shell uname -s)
+GO_ARCH_RAW := $(shell uname -m)
+
+ifeq ($(GO_OS_RAW),Darwin)
+  GO_OS := darwin
+else ifeq ($(GO_OS_RAW),Linux)
+  GO_OS := linux
+else
+  $(error Unsupported operating system $(GO_OS_RAW))
+endif
+
+ifeq ($(GO_ARCH_RAW),x86_64)
+  GO_ARCH := amd64
+else ifeq ($(GO_ARCH_RAW),arm64)
+  GO_ARCH := arm64
+else ifeq ($(GO_ARCH_RAW),aarch64)
+  GO_ARCH := arm64
+else
+  $(error Unsupported architecture $(GO_ARCH_RAW))
+endif
+
+GO_ROOT := $(GO_DIR)/$(GO_VERSION)
+GO_TARBALL := go$(GO_VERSION).$(GO_OS)-$(GO_ARCH).tar.gz
+GO_URL := https://go.dev/dl/$(GO_TARBALL)
+GO := $(GO_ROOT)/bin/go
+GOFMT := $(GO_ROOT)/bin/gofmt
+BLOGWARE := ./blogware/blogware
+
 .PHONY: help
 help:
 	@echo "Supported targets"
@@ -8,23 +39,39 @@ help:
 	@echo "build  - build the blog engine"
 	@echo "serve  - serve the blog content on the PORT"
 	@echo "render - render the website into the DEST directory"
+	@echo "clean  - remove build artifacts and installed toolchains"
+	@echo "deps   - install dependencies"
 
 .PHONY: serve
 serve: build
-	./blogware/blogware -serve localhost:$(PORT)
+	$(BLOGWARE) -serve localhost:$(PORT)
 
 .PHONY: render
 render: build
-	./blogware/blogware -output $(DEST)
+	$(BLOGWARE) -output $(DEST)
 
 .PHONY: test
-test:
-	cd blogware && go test ./... && cd ..
+test: $(GO)
+	cd blogware && ../$(GO) test ./...
 
 .PHONY: lint
-lint:
-	cd blogware && gofmt -l . && go vet && cd ..
+lint: $(GO)
+	cd blogware && ../$(GOFMT) -l . && ../$(GO) vet ./...
 
 .PHONY: build
-build:
-	cd blogware && go build && cd ..
+build: $(GO)
+	$(GO) build -C blogware
+
+.PHONY: deps
+deps: $(GO)
+
+.PHONY: clean
+clean:
+	rm -rf $(GO_DIR) $(DEST) $(BLOGWARE)
+
+$(GO):
+	mkdir -p $(GO_ROOT)
+	curl -fsSL $(GO_URL) -o $(GO_DIR)/$(GO_TARBALL)
+	tar --directory $(GO_ROOT) --strip-components 1 -xzf $(GO_DIR)/$(GO_TARBALL)
+	rm -f $(GO_DIR)/$(GO_TARBALL)
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the complete source of my blog hosted at https://mmappe
 
 # Build instructions
 
-You’ll need [Go](https://go.dev/) and [Make](https://www.gnu.org/software/make/) installed to build the website.
+You’ll need [Make](https://www.gnu.org/software/make/) to build the website.
 Execute the following commands in the repository root:
 
 ```shell


### PR DESCRIPTION
Fetch the `go` tool automatically instead of using the globally installed version.

Closes #48.